### PR TITLE
ci: macos tests too expensive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   # Fast checks first
@@ -50,14 +51,58 @@ jobs:
             build-
 
   # Unit tests - no external services needed
-  test-unit:
-    name: Unit Tests
-    runs-on: ${{ matrix.os }}
+  test-unit-ubuntu:
+    name: Unit Tests (Ubuntu - Full Matrix)
+    runs-on: ubuntu-latest
     needs: lint
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         node: ["18", "20"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: "npm"
+
+      - name: Restore build artifacts
+        uses: actions/cache@v4
+        with:
+          path: dist/
+          key: build-${{ github.sha }}
+          restore-keys: |
+            build-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build if not cached
+        run: |
+          if [ ! -d "dist" ]; then
+            echo "Build artifacts not found, building..."
+            npm run build
+          else
+            echo "Build artifacts found in cache"
+          fi
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+  # Cross-platform tests with minimal matrix - only on main branch and PRs to main
+  test-unit-cross-platform:
+    name: Unit Tests (Cross-Platform)
+    runs-on: ${{ matrix.os }}
+    needs: lint
+    if: >
+      github.event_name == 'push' && github.ref == 'refs/heads/main' ||
+      github.event_name == 'pull_request' && github.base_ref == 'main'
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+        node: ["18"]
 
     steps:
       - uses: actions/checkout@v4
@@ -107,7 +152,7 @@ jobs:
   test-integration:
     name: Integration Tests & Coverage
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, test-unit-ubuntu]
     # Only run integration tests on main branch, PRs to main, or when forced
     if: >
       github.event_name == 'push' && github.ref == 'refs/heads/main' ||
@@ -252,7 +297,7 @@ jobs:
   security:
     name: Security Audit
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [lint, test-unit-ubuntu]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           cache: "npm"
 
       - name: Restore build artifacts
+        id: cache
         uses: actions/cache@v4
         with:
           path: dist/
@@ -79,14 +80,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build if not cached
+      - name: Build
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          if [ ! -d "dist" ]; then
-            echo "Build artifacts not found, building..."
-            npm run build
-          else
-            echo "Build artifacts found in cache"
-          fi
+          echo "Cache miss detected, building..."
+          npm run build
 
       - name: Run unit tests
         run: npm run test:unit
@@ -97,8 +95,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: lint
     if: >
-      github.event_name == 'push' && github.ref == 'refs/heads/main' ||
-      github.event_name == 'pull_request' && github.base_ref == 'main'
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main')
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
@@ -114,6 +112,7 @@ jobs:
           cache: "npm"
 
       - name: Restore build artifacts
+        id: cache
         uses: actions/cache@v4
         with:
           path: dist/
@@ -124,26 +123,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build if not cached (Windows)
+      - name: Build
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          if (!(Test-Path "dist")) {
-            Write-Host "Build artifacts not found, building..."
-            npm run build
-          } else {
-            Write-Host "Build artifacts found in cache"
-          }
-        shell: pwsh
-        if: runner.os == 'Windows'
-
-      - name: Build if not cached (Unix)
-        run: |
-          if [ ! -d "dist" ]; then
-            echo "Build artifacts not found, building..."
-            npm run build
-          else
-            echo "Build artifacts found in cache"
-          fi
-        if: runner.os != 'Windows'
+          echo "Cache miss detected, building..."
+          npm run build
 
       - name: Run unit tests
         run: npm run test:unit
@@ -155,8 +139,8 @@ jobs:
     needs: [lint, test-unit-ubuntu]
     # Only run integration tests on main branch, PRs to main, or when forced
     if: >
-      github.event_name == 'push' && github.ref == 'refs/heads/main' ||
-      github.event_name == 'pull_request' && github.base_ref == 'main' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main') ||
       contains(github.event.head_commit.message, '[integration]') ||
       contains(github.event.pull_request.title, '[integration]')
 
@@ -170,6 +154,7 @@ jobs:
           cache: "npm"
 
       - name: Restore build artifacts
+        id: cache
         uses: actions/cache@v4
         with:
           path: dist/
@@ -232,14 +217,11 @@ jobs:
             echo "✅ Model pull completed"
           fi
 
-      - name: Build if not cached
+      - name: Build
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          if [ ! -d "dist" ]; then
-            echo "Build artifacts not found, building..."
-            npm run build
-          else
-            echo "Build artifacts found in cache"
-          fi
+          echo "Cache miss detected, building..."
+          npm run build
 
       - name: Run all tests with coverage and JUnit report
         run: npm run test:coverage -- --reporter=junit --outputFile=test-report.junit.xml


### PR DESCRIPTION
Remove macos/windows for PR tests and just have ubuntu run.

macos Github Actions minutes cost x10
windows cost x2

I can't afford that for PRs - we don't have special platform tests that need to run